### PR TITLE
feat: 모니터링 서버와 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,10 @@ subprojects {
         // mapstruct
         implementation 'org.mapstruct:mapstruct:1.5.5.Final'
         annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+
+        // monitoring
+        implementation 'io.micrometer:micrometer-registry-prometheus'
+
     }
 
     dependencyManagement {

--- a/loopz-authorization/src/main/java/kr/co/loopz/authorization/config/AuthorizationSecurityConfig.java
+++ b/loopz-authorization/src/main/java/kr/co/loopz/authorization/config/AuthorizationSecurityConfig.java
@@ -27,7 +27,7 @@ public class AuthorizationSecurityConfig {
      */
 
     private static final String[] WHITE_LIST = {
-            "/actuator/health",
+            "/actuator/**",
             "/error",
             "/v3/api-docs/**",
             "/swagger-ui/**",

--- a/loopz-backend/src/main/resources/application.yml
+++ b/loopz-backend/src/main/resources/application.yml
@@ -49,7 +49,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health
+        include: health, prometheus
   endpoint:
     health:
       show-details: always

--- a/loopz-common/build.gradle
+++ b/loopz-common/build.gradle
@@ -25,5 +25,10 @@ dependencies {
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+
+    // zipkin
+//    implementation 'io.zipkin.reporter2:zipkin-reporter-brave'
+    implementation 'io.micrometer:micrometer-tracing-bridge-brave'
+
 }
 

--- a/loopz-common/src/main/java/kr/co/loopz/common/handler/ResponseInterceptor.java
+++ b/loopz-common/src/main/java/kr/co/loopz/common/handler/ResponseInterceptor.java
@@ -30,15 +30,14 @@ public class ResponseInterceptor implements ResponseBodyAdvice {
 
         // swagger 제외
         String path = request.getURI().getPath();
-        if (path.contains("swagger") || path.contains("api-docs") || path.contains("webjars")) {
+
+        if (path.startsWith("/actuator") ||
+                path.contains("swagger") ||
+                path.contains("api-docs") ||
+                path.contains("webjars") ||
+                path.startsWith("/internal")) {
             return body;
         }
-
-        // 내부 API 제외 internal
-        if (path.startsWith("/internal")) {
-            return body;
-        }
-
         // 조건부 메시지 처리: 2xx -> "Success", 그 외 -> "Error"
         String message = (status >= 200 && status < 300) ? "OK" : "Error";
 


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #58
close #59 

## 📝 작업 내용

- MDC 로그 추적
![image](https://github.com/user-attachments/assets/04b2b624-024e-432c-a5dc-9f460f72c69a)
- prometheus 의존성 추가

내일 PR 보면서 의논하기
- internal api 보안 -> WAF로 하기로
- 모니터링 서버는 따로 두고 로그를 수집 하려구합니다
    -> ELK / PLG 중에 고민중입니다 내일 의논해 보아요
- actuator 엔드포인트 보안
- 현재 구조에서도 zipkin으로 분산추적이 될까해서 해봤는데 spring application name이 오버라이드되어서 안될 것 같습니다 ㅜ.ㅜ

## 💬 리뷰 요구사항(선택)

모니터링 레포는 따로 팠습니닷

