### PR TITLE
fix: 동일 주소 예외 수정

### DIFF
--- a/loopz-user-service/src/main/java/kr/co/loopz/user/apiExternal/UserAddressController.java
+++ b/loopz-user-service/src/main/java/kr/co/loopz/user/apiExternal/UserAddressController.java
@@ -1,13 +1,10 @@
 package kr.co.loopz.user.apiExternal;
 
-import feign.Response;
 import jakarta.validation.Valid;
 import kr.co.loopz.user.dto.request.AddressRegisterRequest;
 import kr.co.loopz.user.dto.request.AddressUpdateRequest;
-import kr.co.loopz.user.dto.request.NickNameUpdateRequest;
 import kr.co.loopz.user.dto.response.AddressListResponse;
 import kr.co.loopz.user.dto.response.AddressResponse;
-import kr.co.loopz.user.dto.response.NickNameUpdateResponse;
 import kr.co.loopz.user.service.UserAddressService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/loopz-user-service/src/main/java/kr/co/loopz/user/apiExternal/UserDetailInfoController.java
+++ b/loopz-user-service/src/main/java/kr/co/loopz/user/apiExternal/UserDetailInfoController.java
@@ -2,9 +2,10 @@ package kr.co.loopz.user.apiExternal;
 
 import jakarta.validation.Valid;
 import kr.co.loopz.user.dto.request.NickNameUpdateRequest;
+import kr.co.loopz.user.dto.response.DetailInfoUpdateResponse;
 import kr.co.loopz.user.dto.response.NickNameAvailableResponse;
-import kr.co.loopz.user.dto.response.NickNameUpdateResponse;
 import kr.co.loopz.user.exception.UserException;
+import kr.co.loopz.user.service.UserDetailInfoService;
 import kr.co.loopz.user.service.UserNickNameService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,32 +16,34 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/user/v1/nickname")
+@RequestMapping("/user/v1")
 @RequiredArgsConstructor
 @Slf4j
-public class UserNickNameController {
+public class UserDetailInfoController {
 
     private final UserNickNameService userNickNameService;
+    private final UserDetailInfoService userDetailInfoService;
 
-    @PatchMapping
-    public ResponseEntity<NickNameUpdateResponse> updateNickName(
+    @PatchMapping("/nickname")
+    public ResponseEntity<DetailInfoUpdateResponse> updateNickName(
             @AuthenticationPrincipal User currentUser,
-            @RequestBody @Valid NickNameUpdateRequest nickNameUpdateRequest) {
+            @RequestBody @Valid NickNameUpdateRequest nickNameUpdateRequest)
+    {
 
         String userId = currentUser.getUsername();
         String nickname = nickNameUpdateRequest.nickname();
         log.debug("Received request to update nickname for userId: {}, with request: {}", userId, nickname);
 
-        NickNameUpdateResponse response = userNickNameService.updateNickName(userId, nickname);
+        DetailInfoUpdateResponse response = userNickNameService.updateNickName(userId, nickname);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
 
-    @GetMapping("/validate")
+    @GetMapping("/nickname/validate")
     public ResponseEntity<NickNameAvailableResponse> validateNickName(
-            @RequestParam String nickname) {
-
+            @RequestParam String nickname)
+    {
         try {
             userNickNameService.nickNameValidation(nickname);
         } catch (UserException e) {
@@ -50,5 +53,17 @@ public class UserNickNameController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(new NickNameAvailableResponse(true));
     }
+
+//    @PatchMapping("/gender")
+//    public ResponseEntity<DetailInfoUpdateResponse> updateGender(
+//            @AuthenticationPrincipal User currentUser,
+//            @RequestBody @Valid GenderUpdateRequest genderUpdateRequest
+//    ) {
+//
+//        String userId = currentUser.getUsername();
+//
+//
+//
+//    }
 
 }

--- a/loopz-user-service/src/main/java/kr/co/loopz/user/converter/UserConverter.java
+++ b/loopz-user-service/src/main/java/kr/co/loopz/user/converter/UserConverter.java
@@ -4,7 +4,7 @@ import kr.co.loopz.user.domain.Address;
 import kr.co.loopz.user.domain.UserEntity;
 import kr.co.loopz.user.dto.response.AddressResponse;
 import kr.co.loopz.user.dto.response.AgreeTermsResponse;
-import kr.co.loopz.user.dto.response.NickNameUpdateResponse;
+import kr.co.loopz.user.dto.response.DetailInfoUpdateResponse;
 import kr.co.loopz.user.dto.response.UserInternalRegisterResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -21,7 +21,7 @@ public interface UserConverter {
     UserConverter INSTANCE = Mappers.getMapper(UserConverter.class);
 
     UserInternalRegisterResponse toUserInternalRegisterResponse(UserEntity userEntity);
-    NickNameUpdateResponse toNickNameUpdateResponse(UserEntity user);
+    DetailInfoUpdateResponse toDetailInfoUpdateResponse(UserEntity user);
 
     @Mapping(source = "userTerms.over14", target = "over14")
     @Mapping(source = "userTerms.agreedServiceTerms", target = "agreedServiceTerms")

--- a/loopz-user-service/src/main/java/kr/co/loopz/user/domain/UserEntity.java
+++ b/loopz-user-service/src/main/java/kr/co/loopz/user/domain/UserEntity.java
@@ -43,7 +43,7 @@ public class UserEntity extends BaseTimeEntityWithDeletion {
     private String loginName;
 
     // 닉네임
-    @Column(length = 20, nullable = true, unique = true)
+    @Column(length = 20, nullable = true)
     private String nickName;
 
     @Column(length = 1024)

--- a/loopz-user-service/src/main/java/kr/co/loopz/user/dto/response/DetailInfoUpdateResponse.java
+++ b/loopz-user-service/src/main/java/kr/co/loopz/user/dto/response/DetailInfoUpdateResponse.java
@@ -1,6 +1,6 @@
 package kr.co.loopz.user.dto.response;
 
-public record NickNameUpdateResponse(
+public record DetailInfoUpdateResponse(
         String userId,
         String email,
         String loginName,

--- a/loopz-user-service/src/main/java/kr/co/loopz/user/exception/UserErrorCode.java
+++ b/loopz-user-service/src/main/java/kr/co/loopz/user/exception/UserErrorCode.java
@@ -16,7 +16,7 @@ public enum UserErrorCode implements ErrorCode {
     OBJECT_ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 objectId입니다."),
     NEED_LOGIN(HttpStatus.BAD_REQUEST, "로그인이 필요합니다."),
 
-    ADDRESS_EXISTS(HttpStatus.BAD_REQUEST, "이미 등록된 배송지입니다."),
+    ADDRESS_EXISTS(HttpStatus.CONFLICT, "이미 등록된 배송지입니다."),
     ALREADY_HAS_DEFAULT_ADDRESS(HttpStatus.BAD_REQUEST, "기본 배송지는 1개만 설정 가능합니다."),
     ADDRESS_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 주소입니다."),
     NEED_DEFAULT_ADDRESS(HttpStatus.BAD_REQUEST, "기본배송지 지정이 필요합니다."),

--- a/loopz-user-service/src/main/java/kr/co/loopz/user/exception/UserException.java
+++ b/loopz-user-service/src/main/java/kr/co/loopz/user/exception/UserException.java
@@ -1,15 +1,14 @@
 package kr.co.loopz.user.exception;
 
 import kr.co.loopz.common.exception.CustomException;
-import kr.co.loopz.common.exception.ErrorCode;
 
 public class UserException extends CustomException {
 
-  public UserException(ErrorCode errorCode) {
+  public UserException(UserErrorCode errorCode) {
     super(errorCode);
   }
 
-  public UserException(ErrorCode errorCode, String message) {
+  public UserException(UserErrorCode errorCode, String message) {
     super(errorCode, message);
   }
 

--- a/loopz-user-service/src/main/java/kr/co/loopz/user/repository/AddressRepository.java
+++ b/loopz-user-service/src/main/java/kr/co/loopz/user/repository/AddressRepository.java
@@ -18,7 +18,7 @@ public interface AddressRepository extends JpaRepository<Address, Long> {
 
     Optional<Address> findByIdAndUserId(Long id, String userId);
 
-    List<Address> findAllByUserId(String userId);
+    List<Address> findAllByUserIdOrderByIdAsc(String userId);
 
     boolean existsByUserIdAndAddressId(String userId, String addressId);
 }

--- a/loopz-user-service/src/main/java/kr/co/loopz/user/service/UserDetailInfoService.java
+++ b/loopz-user-service/src/main/java/kr/co/loopz/user/service/UserDetailInfoService.java
@@ -1,0 +1,7 @@
+package kr.co.loopz.user.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserDetailInfoService {
+}

--- a/loopz-user-service/src/main/java/kr/co/loopz/user/service/UserNickNameService.java
+++ b/loopz-user-service/src/main/java/kr/co/loopz/user/service/UserNickNameService.java
@@ -3,7 +3,7 @@ package kr.co.loopz.user.service;
 import com.vane.badwordfiltering.BadWordFiltering;
 import kr.co.loopz.user.converter.UserConverter;
 import kr.co.loopz.user.domain.UserEntity;
-import kr.co.loopz.user.dto.response.NickNameUpdateResponse;
+import kr.co.loopz.user.dto.response.DetailInfoUpdateResponse;
 import kr.co.loopz.user.exception.UserException;
 import kr.co.loopz.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,14 +27,14 @@ public class UserNickNameService {
 
 
     @Transactional
-    public NickNameUpdateResponse updateNickName(String userId, String nickname) {
+    public DetailInfoUpdateResponse updateNickName(String userId, String nickname) {
 
         UserEntity user = userService.findByUserId(userId);
 
         nickNameValidation(nickname);
         user.updateNickName(nickname);
 
-        return userConverter.toNickNameUpdateResponse(user);
+        return userConverter.toDetailInfoUpdateResponse(user);
     }
 
     /**


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #62 
close #37 


## 📝 작업 내용

- patch mapping에도 주소 중복을 검사하도록 수정
- 주소 중복을 409 conflict 예외로 수정
- 주소를 id로 정렬해서 응답하도록 수정
- 주소 로직 리팩토링
- nickname service, user detail service 분리
- nickname controller를 user detail controller로 통합

<img width="791" alt="image" src="https://github.com/user-attachments/assets/b9e98f15-2096-49a0-82f5-00aa5c08ba71" />

<img width="767" alt="image" src="https://github.com/user-attachments/assets/2eaf73f2-6313-4382-92a9-c90954181ae5" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

