### PR TITLE
feat: 좋아요 목록 반환에 exclude sold out 필터 추가

### DIFF
--- a/loopz-product-service/src/main/java/kr/co/loopz/object/dto/request/LikedObjectRequest.java
+++ b/loopz-product-service/src/main/java/kr/co/loopz/object/dto/request/LikedObjectRequest.java
@@ -6,7 +6,8 @@ public record LikedObjectRequest(
         @Min(1)
         int page,
         @Min(1)
-        int size
+        int size,
+        Boolean excludeSoldOut
 ) {
 
         public int page() {

--- a/loopz-product-service/src/main/java/kr/co/loopz/object/repository/query/ObjectQueryRepository.java
+++ b/loopz-product-service/src/main/java/kr/co/loopz/object/repository/query/ObjectQueryRepository.java
@@ -13,6 +13,6 @@ public interface ObjectQueryRepository {
     long countFilteredObjects(BooleanBuilder whereClause);
     Map<String, String> fetchThumbnails(List<String> objectIds);
     Map<String, Boolean> fetchLikeMap(String userId, List<String> objectIds);
-    List<ObjectEntity> findLikedObjects(String userId, Pageable pageable);
-    int countLikedObjects(String userId);
+    List<ObjectEntity> findLikedObjects(String userId, Pageable pageable, boolean excludeSoldOut);
+    int countLikedObjects(String userId, boolean excludeSoldOut);
 }

--- a/loopz-product-service/src/main/java/kr/co/loopz/object/service/LikeService.java
+++ b/loopz-product-service/src/main/java/kr/co/loopz/object/service/LikeService.java
@@ -63,7 +63,8 @@ public class LikeService {
      */
     public BoardResponse getLikedObjects(String userId, LikedObjectRequest request) {
         checkUserValid(userId);
-        return objectBoardService.getLikedBoardResponse(userId, request.page(), request.size());
+        boolean excludeSoldOut = request.excludeSoldOut() != null && request.excludeSoldOut();
+        return objectBoardService.getLikedBoardResponse(userId, request.page(), request.size(), excludeSoldOut);
     }
 
 

--- a/loopz-product-service/src/main/java/kr/co/loopz/object/service/ObjectBoardService.java
+++ b/loopz-product-service/src/main/java/kr/co/loopz/object/service/ObjectBoardService.java
@@ -56,12 +56,12 @@ public class ObjectBoardService {
      * @param size 페이지 크기
      * @return BoardResponse 좋아요한 오브젝트 목록, 썸네일, 좋아요 여부, 다음 페이지 여부
      */
-    public BoardResponse getLikedBoardResponse(String userId, int page, int size) {
+    public BoardResponse getLikedBoardResponse(String userId, int page, int size, boolean excludeSoldOut) {
 
         Pageable pageable = PageRequest.of(page, size);
 
-        List<ObjectEntity> objects = objectRepository.findLikedObjects(userId, pageable);
-        int totalCount = objectRepository.countLikedObjects(userId);
+        List<ObjectEntity> objects = objectRepository.findLikedObjects(userId, pageable, excludeSoldOut);
+        int totalCount = objectRepository.countLikedObjects(userId, excludeSoldOut);
         boolean hasNext = hasNext(objects, size);
 
         return getResponseWithLikedAndImage(userId, objects, totalCount, hasNext);


### PR DESCRIPTION


## #⃣ 연관된 이슈

close #109 

## 📝 작업 내용

좋아요 리스트에서도 품절 제외가 있다고 해서 추가했습니다
여기서 정렬은 좋아요 누른순 정렬만 지원하도록 했습니다

<img width="847" height="634" alt="image" src="https://github.com/user-attachments/assets/dc29ec28-60b6-4402-b02e-d73f03015b41" />
<img width="871" height="633" alt="image" src="https://github.com/user-attachments/assets/4b8a0693-8077-4695-a738-08d19aa38214" />



## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

