### PR TITLE
feat: 주문 상세보기

### DIFF
--- a/loopz-order-service/src/main/java/kr/co/loopz/order/apiExternal/OrderController.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/apiExternal/OrderController.java
@@ -3,7 +3,7 @@ package kr.co.loopz.order.apiExternal;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import kr.co.loopz.order.dto.request.OrderRequest;
-import kr.co.loopz.order.dto.response.ObjectDetailResponse;
+import kr.co.loopz.order.dto.response.OrderDetailResponse;
 import kr.co.loopz.order.dto.response.OrderListResponse;
 import kr.co.loopz.order.dto.response.OrderResponse;
 import kr.co.loopz.order.service.OrderDetailService;
@@ -34,7 +34,8 @@ public class OrderController {
     @Operation(summary = "주문 API")
     public ResponseEntity<OrderResponse> orderObject(
             @AuthenticationPrincipal User currentUser,
-            @RequestBody @Valid OrderRequest request) {
+            @RequestBody @Valid OrderRequest request
+    ) {
 
         String userId = currentUser.getUsername();
 
@@ -56,28 +57,16 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    // 주문 상세 조회
-    @GetMapping("{orderId}/object/{objectId}")
-    public ResponseEntity<ObjectDetailResponse> getOrderDetail(@AuthenticationPrincipal User currentUser,
-                                                               @PathVariable String orderId,
-                                                               @PathVariable String objectId ) {
-
-        String userId = currentUser.getUsername();
-
-        ObjectDetailResponse response = orderDetailService.getOrderDetail(userId,orderId,objectId);
-
-        return ResponseEntity.status(HttpStatus.OK).body(response);
-    }
 
     @GetMapping("/{orderId}")
-    public ResponseEntity<OrderListResponse> getOrder(
+    public ResponseEntity<OrderDetailResponse> getOrder(
             @AuthenticationPrincipal User currentUser,
             @PathVariable String orderId
     ) {
 
         String userId = currentUser.getUsername();
 
-        OrderListResponse response = orderListService.getOrder(userId, orderId);
+        OrderDetailResponse response = orderDetailService.getOrderDetail(userId, orderId);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/apiExternal/OrderController.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/apiExternal/OrderController.java
@@ -3,8 +3,10 @@ package kr.co.loopz.order.apiExternal;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import kr.co.loopz.order.dto.request.OrderRequest;
+import kr.co.loopz.order.dto.response.ObjectDetailResponse;
 import kr.co.loopz.order.dto.response.OrderListResponse;
 import kr.co.loopz.order.dto.response.OrderResponse;
+import kr.co.loopz.order.service.OrderDetailService;
 import kr.co.loopz.order.service.OrderListService;
 import kr.co.loopz.order.service.OrderService;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,7 @@ public class OrderController {
 
     private final OrderService orderService;
     private final OrderListService orderListService;
+    private final OrderDetailService orderDetailService;
 
     // 상품 주문
     @PostMapping()
@@ -47,6 +50,19 @@ public class OrderController {
         String userId = currentUser.getUsername();
 
         List<OrderListResponse> response = orderListService.getOrders(userId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    // 주문 상세 조회
+    @GetMapping("/{objectId}")
+    public ResponseEntity<ObjectDetailResponse> getOrderDetail(@AuthenticationPrincipal User currentUser,
+                                                               @RequestParam String orderId,
+                                                               @PathVariable String objectId ) {
+
+        String userId = currentUser.getUsername();
+
+        ObjectDetailResponse response = orderDetailService.getOrderDetail(userId,orderId,objectId);
 
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/apiExternal/OrderController.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/apiExternal/OrderController.java
@@ -55,9 +55,9 @@ public class OrderController {
     }
 
     // 주문 상세 조회
-    @GetMapping("/{objectId}")
+    @GetMapping("{orderId}/object/{objectId}")
     public ResponseEntity<ObjectDetailResponse> getOrderDetail(@AuthenticationPrincipal User currentUser,
-                                                               @RequestParam String orderId,
+                                                               @PathVariable String orderId,
                                                                @PathVariable String objectId ) {
 
         String userId = currentUser.getUsername();

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/client/ObjectClient.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/client/ObjectClient.java
@@ -1,7 +1,6 @@
 package kr.co.loopz.order.client;
 
 import kr.co.loopz.order.dto.request.DeleteCartItemRequest;
-import kr.co.loopz.order.dto.response.CartWithQuantityResponse;
 import kr.co.loopz.order.dto.response.InternalObjectResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
@@ -33,10 +32,6 @@ public interface ObjectClient {
     // 카트 상품 조회
     @GetMapping("/internal/object/cart")
     boolean checkObjectInCart(@RequestParam String cartId, @RequestParam String objectId);
-
-    // 사용자 카트 존재여부 조회
-    @GetMapping("/internal/cart/user/{userId}")
-    CartWithQuantityResponse getCartByUserId(@PathVariable String userId);
 
     //카트 상품 삭제
     @DeleteMapping("/internal/cart")

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/client/ObjectClient.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/client/ObjectClient.java
@@ -23,6 +23,9 @@ public interface ObjectClient {
     @PostMapping("/internal/objects")
     List<InternalObjectResponse> getObjectListByIds(@RequestBody List<String> requestIds);
 
+    @PostMapping("/internal/object/{objectId}")
+    InternalObjectResponse getObjectById(@PathVariable String objectId);
+
     // 주문 후 재고 감소
     @PostMapping("/internal/object/{objectId}/stock")
     void decreaseStock(@PathVariable String objectId, @RequestParam int quantity);

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/client/ObjectClient.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/client/ObjectClient.java
@@ -23,7 +23,7 @@ public interface ObjectClient {
     @PostMapping("/internal/objects")
     List<InternalObjectResponse> getObjectListByIds(@RequestBody List<String> requestIds);
 
-    @PostMapping("/internal/object/{objectId}")
+    @GetMapping("/internal/object/{objectId}")
     InternalObjectResponse getObjectById(@PathVariable String objectId);
 
     // 주문 후 재고 감소

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/client/UserClient.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/client/UserClient.java
@@ -1,6 +1,7 @@
 package kr.co.loopz.order.client;
 
 
+import kr.co.loopz.order.dto.response.InternalAddressResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,4 +20,9 @@ public interface UserClient {
             @PathVariable("userId") String userId,
             @PathVariable("addressId") String addressId
     );
+
+    @GetMapping("/internal/user/{userId}/addresses/{addressId}")
+    InternalAddressResponse getAddressById( @PathVariable("userId") String userId,
+                                            @PathVariable("addressId") String addressId);
+
 }

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/converter/OrderConverter.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/converter/OrderConverter.java
@@ -77,5 +77,6 @@ public interface OrderConverter {
         );
 
     }
+
 }
 

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/converter/OrderConverter.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/converter/OrderConverter.java
@@ -86,7 +86,6 @@ public interface OrderConverter {
         MyOrderObjectResponse objectResponse = toMyOrderObjectResponse(orderItem, objectDetail);
 
         return new ObjectDetailResponse(
-                order.getOrderNumber(),
                 order.getOrderId(),
                 objectResponse,
                 address,

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/converter/OrderConverter.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/converter/OrderConverter.java
@@ -2,11 +2,7 @@ package kr.co.loopz.order.converter;
 
 import kr.co.loopz.order.domain.Order;
 import kr.co.loopz.order.domain.OrderItem;
-import kr.co.loopz.order.dto.response.InternalObjectResponse;
-import kr.co.loopz.order.dto.response.ObjectResponse;
-import kr.co.loopz.order.dto.response.OrderListResponse;
-import kr.co.loopz.order.dto.response.MyOrderObjectResponse;
-import kr.co.loopz.order.dto.response.OrderResponse;
+import kr.co.loopz.order.dto.response.*;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -77,6 +73,31 @@ public interface OrderConverter {
         );
 
     }
+
+    default ObjectDetailResponse toObjectDetailResponse(
+            Order order,
+            OrderItem orderItem,
+            InternalObjectResponse objectDetail,
+            InternalAddressResponse address,
+            int shippingFee
+    ) {
+        long productPrice = orderItem.getPurchasePrice() * orderItem.getQuantity();
+        long totalPayment = productPrice + shippingFee;
+
+        MyOrderObjectResponse objectResponse = toMyOrderObjectResponse(orderItem, objectDetail);
+
+        return new ObjectDetailResponse(
+                order.getOrderNumber(),
+                order.getOrderId(),
+                objectResponse,
+                address,
+                shippingFee,
+                productPrice,
+                totalPayment,
+                order.getPaymentMethod()
+        );
+    }
+
 
 }
 

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/domain/Order.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/domain/Order.java
@@ -79,8 +79,10 @@ public class Order {
         this.orderNumber = orderNumber;
     }
 
+    private static final DateTimeFormatter ORDER_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
     private static String generateOrderNumber() {
-        String date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String date = LocalDate.now().format(ORDER_DATE_FORMATTER);
         String random = UUID.randomUUID().toString()
                 .replaceAll("-", "")
                 .substring(0, 6)

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/domain/Order.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/domain/Order.java
@@ -9,6 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -28,6 +30,9 @@ public class Order {
 
     @Column(unique = true, nullable = false)
     private String orderId;
+
+    @Column(unique = true, nullable = false)
+    private String orderNumber;
 
     @Column(nullable = false)
     private String userId;
@@ -55,6 +60,7 @@ public class Order {
                 .addressId(request.addressId())
                 .paymentMethod(request.paymentMethod())
                 .deliveryRequest(request.deliveryRequest())
+                .orderNumber(generateOrderNumber())
                 .build();
     }
 
@@ -63,12 +69,23 @@ public class Order {
     private Order(String userId,
                  String addressId,
                  PaymentMethod paymentMethod,
-                 String deliveryRequest) {
+                 String deliveryRequest,
+                  String orderNumber) {
         this.orderId = UUID.randomUUID().toString();
         this.userId = userId;
         this.addressId = addressId;
         this.paymentMethod = paymentMethod;
         this.deliveryRequest = deliveryRequest;
+        this.orderNumber = orderNumber;
+    }
+
+    private static String generateOrderNumber() {
+        String date = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String random = UUID.randomUUID().toString()
+                .replaceAll("-", "")
+                .substring(0, 6)
+                .toUpperCase();
+        return date + "-" + random;
     }
 
 

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/domain/Order.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/domain/Order.java
@@ -31,9 +31,6 @@ public class Order {
     @Column(unique = true, nullable = false)
     private String orderId;
 
-    @Column(unique = true, nullable = false)
-    private String orderNumber;
-
     @Column(nullable = false)
     private String userId;
 
@@ -60,7 +57,6 @@ public class Order {
                 .addressId(request.addressId())
                 .paymentMethod(request.paymentMethod())
                 .deliveryRequest(request.deliveryRequest())
-                .orderNumber(generateOrderNumber())
                 .build();
     }
 
@@ -69,26 +65,15 @@ public class Order {
     private Order(String userId,
                  String addressId,
                  PaymentMethod paymentMethod,
-                 String deliveryRequest,
-                  String orderNumber) {
+                 String deliveryRequest) {
         this.orderId = UUID.randomUUID().toString();
         this.userId = userId;
         this.addressId = addressId;
         this.paymentMethod = paymentMethod;
         this.deliveryRequest = deliveryRequest;
-        this.orderNumber = orderNumber;
     }
 
-    private static final DateTimeFormatter ORDER_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
 
-    private static String generateOrderNumber() {
-        String date = LocalDate.now().format(ORDER_DATE_FORMATTER);
-        String random = UUID.randomUUID().toString()
-                .replaceAll("-", "")
-                .substring(0, 6)
-                .toUpperCase();
-        return date + "-" + random;
-    }
 
 
 

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/domain/Order.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/domain/Order.java
@@ -1,7 +1,6 @@
 package kr.co.loopz.order.domain;
 
 import jakarta.persistence.*;
-import kr.co.loopz.order.domain.enums.OrderStatus;
 import kr.co.loopz.order.domain.enums.PaymentMethod;
 import kr.co.loopz.order.dto.request.OrderRequest;
 import lombok.AllArgsConstructor;
@@ -11,6 +10,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.Random;
 import java.util.UUID;
 
 import static jakarta.persistence.GenerationType.IDENTITY;
@@ -44,6 +44,8 @@ public class Order {
     @Column(length = 500)
     private String deliveryRequest;
 
+    @Column(unique = true)
+    private String orderNumber;
 
     /**
      * 주문 생성 팩토리 메서드
@@ -67,13 +69,19 @@ public class Order {
                  PaymentMethod paymentMethod,
                  String deliveryRequest) {
         this.orderId = UUID.randomUUID().toString();
+        this.orderNumber = createOrderNumber();
+
         this.userId = userId;
         this.addressId = addressId;
         this.paymentMethod = paymentMethod;
         this.deliveryRequest = deliveryRequest;
     }
 
-
+    private String createOrderNumber() {
+        String datePart = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+        String randomPart = String.format("%07d", new Random().nextInt(10_000_000));
+        return datePart + "-" + randomPart;
+    }
 
 
 

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/CartItemResponse.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/CartItemResponse.java
@@ -1,7 +1,0 @@
-package kr.co.loopz.order.dto.response;
-
-public record CartItemResponse(
-        ObjectResponse object,
-        int quantity
-){
-}

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/CartWithQuantityResponse.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/CartWithQuantityResponse.java
@@ -1,8 +1,0 @@
-package kr.co.loopz.order.dto.response;
-
-import java.util.List;
-
-public record CartWithQuantityResponse(
-    String cartId,
-    List<CartItemResponse> items
-) {}

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/InternalAddressResponse.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/InternalAddressResponse.java
@@ -1,0 +1,13 @@
+package kr.co.loopz.order.dto.response;
+
+public record InternalAddressResponse(
+        String addressId,
+        String userId,
+        String recipientName,
+        String phoneNumber,
+        String zoneCode,
+        String address,
+        String addressDetail,
+        boolean defaultAddress
+){
+}

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/ObjectDetailResponse.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/ObjectDetailResponse.java
@@ -1,0 +1,14 @@
+package kr.co.loopz.order.dto.response;
+
+import kr.co.loopz.order.domain.enums.OrderStatus;
+
+public record ObjectDetailResponse(
+
+        MyOrderObjectResponse objectResponse,
+        InternalAddressResponse address,
+        int shippingFee,
+        long totalProductPrice,
+        long totalPayment
+
+) {
+}

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/ObjectDetailResponse.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/ObjectDetailResponse.java
@@ -1,6 +1,7 @@
 package kr.co.loopz.order.dto.response;
 
 import kr.co.loopz.order.domain.enums.OrderStatus;
+import kr.co.loopz.order.domain.enums.PaymentMethod;
 
 public record ObjectDetailResponse(
 
@@ -8,7 +9,8 @@ public record ObjectDetailResponse(
         InternalAddressResponse address,
         int shippingFee,
         long totalProductPrice,
-        long totalPayment
+        long totalPayment,
+        PaymentMethod paymentMethod
 
 ) {
 }

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/ObjectDetailResponse.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/ObjectDetailResponse.java
@@ -5,6 +5,8 @@ import kr.co.loopz.order.domain.enums.PaymentMethod;
 
 public record ObjectDetailResponse(
 
+        String orderNumber,
+        String orderId,
         MyOrderObjectResponse objectResponse,
         InternalAddressResponse address,
         int shippingFee,

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/ObjectDetailResponse.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/ObjectDetailResponse.java
@@ -5,7 +5,6 @@ import kr.co.loopz.order.domain.enums.PaymentMethod;
 
 public record ObjectDetailResponse(
 
-        String orderNumber,
         String orderId,
         MyOrderObjectResponse objectResponse,
         InternalAddressResponse address,

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/OrderDetailResponse.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/OrderDetailResponse.java
@@ -1,17 +1,17 @@
 package kr.co.loopz.order.dto.response;
 
-import kr.co.loopz.order.domain.enums.OrderStatus;
 import kr.co.loopz.order.domain.enums.PaymentMethod;
 
-public record ObjectDetailResponse(
+import java.util.List;
 
+public record OrderDetailResponse(
         String orderId,
-        MyOrderObjectResponse objectResponse,
+        String orderNumber,
+        PaymentMethod paymentMethod,
+        List<PurchasedObjectResponse> objects,
         InternalAddressResponse address,
         int shippingFee,
         long totalProductPrice,
-        long totalPayment,
-        PaymentMethod paymentMethod
-
+        long totalPayment
 ) {
 }

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/OrderListResponse.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/OrderListResponse.java
@@ -1,12 +1,9 @@
 package kr.co.loopz.order.dto.response;
 
-import kr.co.loopz.order.domain.enums.OrderStatus;
-import kr.co.loopz.order.domain.enums.PaymentMethod;
-
 import java.util.List;
 
 public record OrderListResponse(
         String orderId,
-        List<MyOrderObjectResponse> objects
+        List<PurchasedObjectResponse> objects
 ) {
 }

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/PurchasedObjectResponse.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/dto/response/PurchasedObjectResponse.java
@@ -4,12 +4,13 @@ import kr.co.loopz.order.domain.enums.OrderStatus;
 
 import java.time.LocalDateTime;
 
-public record MyOrderObjectResponse(
+public record PurchasedObjectResponse(
         String objectId,
         String objectName,
         OrderStatus status,
+        String intro,
         String imageUrl,
-        Long totalPrice,
+        Long purchasePrice,
         int quantity,
         LocalDateTime orderDate
 ) {

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/exception/OrderErrorCode.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/exception/OrderErrorCode.java
@@ -13,7 +13,8 @@ public enum OrderErrorCode implements ErrorCode {
     OBJECT_ID_NOT_FOUND(HttpStatus.BAD_REQUEST, "해당 상품을 찾을 수 없습니다."),
     OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "재고가 부족합니다."),
     CART_ITEM_NOT_FOUND(HttpStatus.BAD_REQUEST, "장바구니에 존재하지 않는 상품입니다."),
-    ORDER_TERM_NOT_AGREED(HttpStatus.BAD_REQUEST, "약관 동의가 필요합니다.");
+    ORDER_TERM_NOT_AGREED(HttpStatus.BAD_REQUEST, "약관 동의가 필요합니다."),
+    ORDER_NOT_FOUND(HttpStatus.BAD_REQUEST, "사용자와 일치하는 주문을 찾을 수 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/repository/OrderItemRepository.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/repository/OrderItemRepository.java
@@ -2,10 +2,16 @@ package kr.co.loopz.order.repository;
 
 import kr.co.loopz.order.domain.OrderItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
 
     List<OrderItem> findAllByOrderId(String orderId);
+
+    Optional<OrderItem> findByOrderIdAndObjectId(String orderId, String objectId);
+
 }

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/repository/OrderRepository.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/repository/OrderRepository.java
@@ -4,9 +4,12 @@ import kr.co.loopz.order.domain.Order;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
     List<Order> findAllByUserId(String userId);
+
+    Optional<Order> findByOrderIdAndUserId(String orderId, String userId);
 
 }

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/service/OrderDetailService.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/service/OrderDetailService.java
@@ -5,6 +5,7 @@ import kr.co.loopz.order.client.UserClient;
 import kr.co.loopz.order.converter.OrderConverter;
 import kr.co.loopz.order.domain.Order;
 import kr.co.loopz.order.domain.OrderItem;
+import kr.co.loopz.order.domain.enums.PaymentMethod;
 import kr.co.loopz.order.dto.response.*;
 import kr.co.loopz.order.dto.response.InternalAddressResponse;
 import kr.co.loopz.order.exception.OrderException;
@@ -43,6 +44,8 @@ public class OrderDetailService {
         // 주소 조회
         InternalAddressResponse address = userClient.getAddressById(order.getUserId(), order.getAddressId());
 
+        PaymentMethod paymentMethod = order.getPaymentMethod();
+
         long productPrice = orderItem.getPurchasePrice() * orderItem.getQuantity();
         long totalPayment = productPrice + SHIPPING_FEE;
 
@@ -53,7 +56,8 @@ public class OrderDetailService {
                 address,
                 SHIPPING_FEE,
                 productPrice,
-                totalPayment
+                totalPayment,
+                paymentMethod
         );
     }
 

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/service/OrderDetailService.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/service/OrderDetailService.java
@@ -34,7 +34,6 @@ public class OrderDetailService {
 
         // userId + orderId로 주문 확인
         Order order = getOrder(orderId, userId);
-        String orderNumber = order.getOrderNumber();
 
         // 주문의 OrderItem 조회
         OrderItem orderItem = getOrderItem(orderId, objectId);
@@ -45,23 +44,8 @@ public class OrderDetailService {
         // 주소 조회
         InternalAddressResponse address = userClient.getAddressById(order.getUserId(), order.getAddressId());
 
-        PaymentMethod paymentMethod = order.getPaymentMethod();
+        return orderConverter.toObjectDetailResponse(order, orderItem, objectDetail, address, SHIPPING_FEE);
 
-        long productPrice = orderItem.getPurchasePrice() * orderItem.getQuantity();
-        long totalPayment = productPrice + SHIPPING_FEE;
-
-        MyOrderObjectResponse objectResponse = orderConverter.toMyOrderObjectResponse(orderItem, objectDetail);
-
-        return new ObjectDetailResponse(
-                orderNumber,
-                orderId,
-                objectResponse,
-                address,
-                SHIPPING_FEE,
-                productPrice,
-                totalPayment,
-                paymentMethod
-        );
     }
 
     private Order getOrder(String orderId, String userId) {

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/service/OrderDetailService.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/service/OrderDetailService.java
@@ -34,6 +34,7 @@ public class OrderDetailService {
 
         // userId + orderId로 주문 확인
         Order order = getOrder(orderId, userId);
+        String orderNumber = order.getOrderNumber();
 
         // 주문의 OrderItem 조회
         OrderItem orderItem = getOrderItem(orderId, objectId);
@@ -52,6 +53,8 @@ public class OrderDetailService {
         MyOrderObjectResponse objectResponse = orderConverter.toMyOrderObjectResponse(orderItem, objectDetail);
 
         return new ObjectDetailResponse(
+                orderNumber,
+                orderId,
                 objectResponse,
                 address,
                 SHIPPING_FEE,

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/service/OrderDetailService.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/service/OrderDetailService.java
@@ -1,0 +1,69 @@
+package kr.co.loopz.order.service;
+
+import kr.co.loopz.order.client.ObjectClient;
+import kr.co.loopz.order.client.UserClient;
+import kr.co.loopz.order.converter.OrderConverter;
+import kr.co.loopz.order.domain.Order;
+import kr.co.loopz.order.domain.OrderItem;
+import kr.co.loopz.order.dto.response.*;
+import kr.co.loopz.order.dto.response.InternalAddressResponse;
+import kr.co.loopz.order.exception.OrderException;
+import kr.co.loopz.order.repository.OrderItemRepository;
+import kr.co.loopz.order.repository.OrderRepository;
+import static kr.co.loopz.order.constants.OrderConstants.SHIPPING_FEE;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.Internal;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static kr.co.loopz.order.exception.OrderErrorCode.*;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class OrderDetailService {
+
+    private final OrderRepository orderRepository;
+    private final OrderItemRepository orderItemRepository;
+    private final ObjectClient objectClient;
+    private final UserClient userClient;
+    private final OrderConverter orderConverter;
+
+    public ObjectDetailResponse getOrderDetail(String userId, String orderId, String objectId) {
+
+        // userId + orderId로 주문 확인
+        Order order = getOrder(orderId, userId);
+
+        // 주문의 OrderItem 조회
+        OrderItem orderItem = getOrderItem(orderId, objectId);
+
+        // 상품 상세 조회
+        InternalObjectResponse objectDetail = objectClient.getObjectById(objectId);
+
+        // 주소 조회
+        InternalAddressResponse address = userClient.getAddressById(order.getUserId(), order.getAddressId());
+
+        long productPrice = orderItem.getPurchasePrice() * orderItem.getQuantity();
+        long totalPayment = productPrice + SHIPPING_FEE;
+
+        MyOrderObjectResponse objectResponse = orderConverter.toMyOrderObjectResponse(orderItem, objectDetail);
+
+        return new ObjectDetailResponse(
+                objectResponse,
+                address,
+                SHIPPING_FEE,
+                productPrice,
+                totalPayment
+        );
+    }
+
+    private Order getOrder(String orderId, String userId) {
+        return orderRepository.findByOrderIdAndUserId(orderId, userId)
+                .orElseThrow(() -> new OrderException(ORDER_NOT_FOUND, "orderId: " + orderId));
+    }
+
+    private OrderItem getOrderItem(String orderId, String objectId) {
+        return orderItemRepository.findByOrderIdAndObjectId(orderId, objectId)
+                .orElseThrow(() -> new OrderException(OBJECT_ID_NOT_FOUND, "objectId: " + objectId));
+    }
+}

--- a/loopz-order-service/src/main/java/kr/co/loopz/order/service/OrderListService.java
+++ b/loopz-order-service/src/main/java/kr/co/loopz/order/service/OrderListService.java
@@ -5,7 +5,7 @@ import kr.co.loopz.order.converter.OrderConverter;
 import kr.co.loopz.order.domain.Order;
 import kr.co.loopz.order.domain.OrderItem;
 import kr.co.loopz.order.dto.response.InternalObjectResponse;
-import kr.co.loopz.order.dto.response.MyOrderObjectResponse;
+import kr.co.loopz.order.dto.response.PurchasedObjectResponse;
 import kr.co.loopz.order.dto.response.OrderListResponse;
 import kr.co.loopz.order.exception.OrderException;
 import kr.co.loopz.order.repository.OrderItemRepository;
@@ -38,7 +38,6 @@ public class OrderListService {
      * @param userId 사용자 UUID
      * @return 나의 주문 목록
      */
-
     public List<OrderListResponse> getOrders(String userId) {
 
         List<Order> orders = orderRepository.findAllByUserId(userId);
@@ -70,13 +69,13 @@ public class OrderListService {
                 .collect(Collectors.toMap(InternalObjectResponse::objectId, Function.identity()));
 
         // MyOrderObjectResponse 리스트 생성
-        List<MyOrderObjectResponse> objectResponses = orderItems.stream()
+        List<PurchasedObjectResponse> objectResponses = orderItems.stream()
                 .map(item -> {
                     InternalObjectResponse detail = objectDetailsMap.get(item.getObjectId());
                     if (detail == null) {
                         throw new OrderException(OBJECT_ID_NOT_FOUND, "ObjectId:" + item.getObjectId());
                     }
-                    return orderConverter.toMyOrderObjectResponse(item, detail);
+                    return orderConverter.toPurchasedObjectResponse(item, detail);
                 })
                 .toList();
 
@@ -84,7 +83,7 @@ public class OrderListService {
     }
 
     //  상품 상세 정보 호출 (object 서비스 호출)
-    private List<InternalObjectResponse> getObjectDetailsByOrderItems(List<OrderItem> orderItems) {
+    public List<InternalObjectResponse> getObjectDetailsByOrderItems(List<OrderItem> orderItems) {
         List<String> objectIds = orderItems.stream()
                 .map(OrderItem::getObjectId)
                 .distinct()

--- a/loopz-product-service/src/main/java/kr/co/loopz/object/apiInternal/InternalObjectController.java
+++ b/loopz-product-service/src/main/java/kr/co/loopz/object/apiInternal/InternalObjectController.java
@@ -38,7 +38,7 @@ public class InternalObjectController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
-    @PostMapping("/object/{objectId}")
+    @GetMapping("/object/{objectId}")
     public ResponseEntity<ObjectResponse> getObject(
             @PathVariable String objectId
     ) {

--- a/loopz-product-service/src/main/java/kr/co/loopz/object/apiInternal/InternalObjectController.java
+++ b/loopz-product-service/src/main/java/kr/co/loopz/object/apiInternal/InternalObjectController.java
@@ -38,6 +38,14 @@ public class InternalObjectController {
         return ResponseEntity.status(HttpStatus.OK).body(response);
     }
 
+    @PostMapping("/object/{objectId}")
+    public ResponseEntity<ObjectResponse> getObject(
+            @PathVariable String objectId
+    ) {
+        ObjectResponse response = objectDetailService.getObjectById(objectId);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
     // objectId 존재 여부 확인 API
     @GetMapping("/objects/{objectId}/exists")
     public ResponseEntity<Boolean> checkObjectIdExists(@PathVariable String objectId) {

--- a/loopz-product-service/src/main/java/kr/co/loopz/object/domain/CartItem.java
+++ b/loopz-product-service/src/main/java/kr/co/loopz/object/domain/CartItem.java
@@ -1,6 +1,7 @@
 package kr.co.loopz.object.domain;
 
 import jakarta.persistence.*;
+import kr.co.loopz.common.domain.BaseTimeEntity;
 import lombok.*;
 
 @Entity
@@ -8,7 +9,7 @@ import lombok.*;
 @Getter
 @AllArgsConstructor
 @Table(name = "cart_object_item")
-public class CartItem {
+public class CartItem extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/loopz-product-service/src/main/java/kr/co/loopz/object/service/CartService.java
+++ b/loopz-product-service/src/main/java/kr/co/loopz/object/service/CartService.java
@@ -16,10 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -100,7 +97,10 @@ public class CartService {
             return new CartListResponse(Collections.emptyList(),Collections.emptyList());
         }
 
-        List<CartItem> cartItems = cartItemRepository.findByCartId(cart.getCartId());
+        List<CartItem> cartItems = cartItemRepository.findByCartId(cart.getCartId())
+                .stream()
+                .sorted(Comparator.comparing(CartItem::getCreatedAt))
+                .toList();
 
         List<String> objectIds = cartItems.stream()
                 .map(CartItem::getObjectId)

--- a/loopz-user-service/src/main/java/kr/co/loopz/user/apiInternal/InternalUserController.java
+++ b/loopz-user-service/src/main/java/kr/co/loopz/user/apiInternal/InternalUserController.java
@@ -23,6 +23,7 @@ public class InternalUserController {
     private final UserRepository userRepository;
     private final AddressRepository addressRepository;
     private final UserAddressService userAddressService;
+    private final UserConverter userConverter;
 
     @PostMapping
     public UserInternalRegisterResponse getOrCreateUser(
@@ -50,6 +51,6 @@ public class InternalUserController {
     @GetMapping("/{userId}/addresses/{addressId}")
     public AddressResponse getAddressById(@PathVariable String userId,@PathVariable String addressId) {
         Address address = userAddressService.getAddress(userId, addressId);
-        return UserConverter.INSTANCE.toAddressResponse(address);
+        return userConverter.INSTANCE.toAddressResponse(address);
     }
 }

--- a/loopz-user-service/src/main/java/kr/co/loopz/user/apiInternal/InternalUserController.java
+++ b/loopz-user-service/src/main/java/kr/co/loopz/user/apiInternal/InternalUserController.java
@@ -1,9 +1,13 @@
 package kr.co.loopz.user.apiInternal;
 
+import kr.co.loopz.user.converter.UserConverter;
+import kr.co.loopz.user.domain.Address;
 import kr.co.loopz.user.dto.request.UserInternalRegisterRequest;
+import kr.co.loopz.user.dto.response.AddressResponse;
 import kr.co.loopz.user.dto.response.UserInternalRegisterResponse;
 import kr.co.loopz.user.repository.AddressRepository;
 import kr.co.loopz.user.repository.UserRepository;
+import kr.co.loopz.user.service.UserAddressService;
 import kr.co.loopz.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,6 +22,7 @@ public class InternalUserController {
     private final UserService userService;
     private final UserRepository userRepository;
     private final AddressRepository addressRepository;
+    private final UserAddressService userAddressService;
 
     @PostMapping
     public UserInternalRegisterResponse getOrCreateUser(
@@ -42,4 +47,9 @@ public class InternalUserController {
         return addressRepository.existsByUserIdAndAddressId(userId, addressId);
     }
 
+    @GetMapping("/{userId}/addresses/{addressId}")
+    public AddressResponse getAddressById(@PathVariable String userId,@PathVariable String addressId) {
+        Address address = userAddressService.getAddress(userId, addressId);
+        return UserConverter.INSTANCE.toAddressResponse(address);
+    }
 }

--- a/loopz-user-service/src/main/java/kr/co/loopz/user/service/UserAddressService.java
+++ b/loopz-user-service/src/main/java/kr/co/loopz/user/service/UserAddressService.java
@@ -76,6 +76,8 @@ public class UserAddressService {
         addressRepository.delete(address);
     }
 
+
+
     // 기존 기본 배송지 해제
     private void unsetDefaultAddress(String userId) {
         addressRepository.findByUserIdAndDefaultAddressTrue(userId)
@@ -114,7 +116,7 @@ public class UserAddressService {
         }
     }
 
-    private Address getAddress(String userId, String addressId) {
+    public Address getAddress(String userId, String addressId) {
         return addressRepository.findByAddressIdAndUserId(addressId, userId)
                 .orElseThrow(() -> new UserException(ADDRESS_NOT_FOUND, "Address id: " + addressId));
     }


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #107 

## 📝 작업 내용
'
<img width="1388" height="714" alt="image" src="https://github.com/user-attachments/assets/d16c3c78-19ab-407c-b1cd-7d8318426b4e" />

<img width="1302" height="816" alt="image" src="https://github.com/user-attachments/assets/16c7f292-775a-4165-a1be-dbcfe2c5d5c9" />

일단 orderNum 추가해서 주문날짜 + UUID 형식으로 반환하도록 했습니당

## 💬 리뷰 요구사항(선택)

- 취소/반품 시 상세보기는  CANCELED, REFUND_REQUESTED, REFUND_COMPLETE 일 때 반환하는 값으로 따로 API 만드는게 낫겠죠?
- 그리고 주문 상세보기에서  CANCELED, REFUND_REQUESTED, REFUND_COMPLETE  얘네일 상태는 지금 만든 주문 상세는 보지 못하도록 에러 처리하는게 나을까요??
<img width="448" height="898" alt="image" src="https://github.com/user-attachments/assets/07a63fb9-df9b-48e0-bff3-424a9fb37fe1" />

