### PR TITLE
fix: 웹훅 중복 수신 오류 

### DIFF
--- a/loopz-payment-service/src/main/java/kr/co/loopz/payment/repository/PaymentRepository.java
+++ b/loopz-payment-service/src/main/java/kr/co/loopz/payment/repository/PaymentRepository.java
@@ -4,5 +4,5 @@ import kr.co.loopz.payment.domain.PaymentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepository extends JpaRepository<PaymentEntity, Long> {
-
+    boolean existsByPaymentId(String paymentId);
 }

--- a/loopz-payment-service/src/main/java/kr/co/loopz/payment/service/PaymentService.java
+++ b/loopz-payment-service/src/main/java/kr/co/loopz/payment/service/PaymentService.java
@@ -82,6 +82,8 @@ public class PaymentService {
 
         requestToProductServiceDecreaseStockDeleteCart(userId, response.objects());
         requestToOrderServiceChangeOrderStatus(response.orderId());
+
+        payment.makeWebhookVerified();
     }
 
 

--- a/loopz-payment-service/src/main/java/kr/co/loopz/payment/service/PaymentService.java
+++ b/loopz-payment-service/src/main/java/kr/co/loopz/payment/service/PaymentService.java
@@ -72,6 +72,12 @@ public class PaymentService {
      */
     @Transactional
     public void syncPaymentAndUpdateStock(String paymentId) {
+
+        if (paymentRepository.existsByPaymentId(paymentId)) {
+            log.info("이미 처리된 결제 웹훅입니다. 중복 처리를 방지합니다. 결제 ID: {}", paymentId);
+            return;
+        }
+
         PaymentCompleteResponse response = syncPayment(paymentId, null);
         log.info("웹훅 수신 후 결제 정보 동기화 성공, 결제 ID: {} 재고 및 장바구니 데이터 싱크 처리 시작", paymentId);
 


### PR DESCRIPTION

## #⃣ 연관된 이슈

close #124 

## 📝 작업 내용

웹훅 중복 수신으로 인해 재고 정합성이 깨지는 문제를 해결하기 위해
중복 수신 확인 로직을 추가했습니다
이걸 멱등성 확보라고 부른다고 하네요 (Idempotency)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

