### PR TITLE
fix: 닉네임 제한 강화

### DIFF
--- a/loopz-user-service/src/main/java/kr/co/loopz/user/service/UserNickNameService.java
+++ b/loopz-user-service/src/main/java/kr/co/loopz/user/service/UserNickNameService.java
@@ -79,14 +79,18 @@ public class UserNickNameService {
         if (badWordFiltering.check(nickname) || badWordFiltering.blankCheck(nickname)) {
             throw new UserException(NICKNAME_INVALID, "닉네임에 부적절한 단어가 포함되어 있습니다.");
         }
-        if (RESERVED_NICKNAMES.contains(nickname.toLowerCase())) {
-            throw new UserException(NICKNAME_INVALID, "사용할 수 없는 닉네임입니다.");
+
+        String lowerNickname = nickname.toLowerCase();
+        for (String reserved : RESERVED_NICKNAMES) {
+            if (lowerNickname.contains(reserved.toLowerCase())) {
+                throw new UserException(NICKNAME_INVALID, "사용할 수 없는 단어가 닉네임에 포함되어 있습니다.");
+            }
         }
     }
 
     // 예약어 추가
     private static final Set<String> RESERVED_NICKNAMES = Set.of(
-            "admin", "manager", "system", "root", "운영자", "관리자", "null"
+            "admin", "manager", "system", "root", "운영자", "관리자", "null","loopz"
     );
 
 


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #132 

## 📝 작업 내용

 "admin", "manager", "system", "root", "운영자", "관리자", "null","loopz" 이 포함되는 단어들 모두 불가
(Admin, LOOPZ, roots, Loopzp, 내가운영자 등)

## 💬 리뷰 요구사항(선택)

