### PR TITLE
chore: Redis를 Elastic Cache로 이전

### DIFF
--- a/loopz-backend/src/main/resources/application-local.yml
+++ b/loopz-backend/src/main/resources/application-local.yml
@@ -7,6 +7,7 @@ POSTGRESQL_DATABASE: loopz_db
 
 REDIS_HOST: localhost
 REDIS_PORT: 6379
+REDIS_SSL_ENABLED: false
 
 BASE_URL: http://localhost:8080
 FRONT_URL: http://localhost:3000

--- a/loopz-backend/src/main/resources/application.yml
+++ b/loopz-backend/src/main/resources/application.yml
@@ -18,6 +18,8 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+      ssl:
+        enabled: ${REDIS_SSL_ENABLED:false}
 
   security:
     oauth2:

--- a/loopz-common/src/main/java/kr/co/loopz/common/redis/config/RedisConfig.java
+++ b/loopz-common/src/main/java/kr/co/loopz/common/redis/config/RedisConfig.java
@@ -1,10 +1,16 @@
 package kr.co.loopz.common.redis.config;
 
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.SocketOptions;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+import java.time.Duration;
 
 @Configuration
 public class RedisConfig {
@@ -15,9 +21,40 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
+    @Value("${spring.data.redis.ssl.enabled}")
+    private boolean sslEnabled;
+
     @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+    public RedisConnectionFactory factory() {
+
+        // standalone mode
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+        configuration.setHostName(host);
+        configuration.setPort(port);
+
+        // socket options
+        SocketOptions socketOptions = SocketOptions.builder()
+                .connectTimeout(Duration.ofMillis(100L))
+                .keepAlive(true)
+                .build();
+
+        // client options
+        ClientOptions clientOptions = ClientOptions.builder()
+                .socketOptions(socketOptions)
+                .build();
+
+        // Lettuce Client option
+        LettuceClientConfiguration.LettuceClientConfigurationBuilder builder = LettuceClientConfiguration.builder()
+                .clientOptions(clientOptions)
+                .commandTimeout(Duration.ofMillis(3000L));
+
+        if (sslEnabled) {
+            builder.useSsl();
+        }
+
+        LettuceClientConfiguration clientConfiguration = builder.build();
+
+        return new LettuceConnectionFactory(configuration, clientConfiguration);
     }
 
 

--- a/loopz-product-service/src/main/java/kr/co/loopz/object/config/RedissonConfig.java
+++ b/loopz-product-service/src/main/java/kr/co/loopz/object/config/RedissonConfig.java
@@ -16,14 +16,18 @@ public class RedissonConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
+    @Value("${spring.data.redis.ssl.enabled}")
+    private boolean sslEnabled;
 
-    private static final String REDIS_PREFIX = "redis://";
 
     @Bean
     public RedissonClient redissonClient() {
+
+        String prefix = sslEnabled ? "rediss://" : "redis://";
+
         Config config = new Config();
         config.useSingleServer()
-                .setAddress(REDIS_PREFIX + redisHost + ":" + port);
+                .setAddress(prefix + redisHost + ":" + port);
         return Redisson.create(config);
     }
 }


### PR DESCRIPTION

## #⃣ 연관된 이슈

close #129 

## 📝 작업 내용

캐싱이 더 들어가기 전에 운영 환경 구축이 먼저인것 같아서 빠르게 진행했습니다!.!

코드상으로 lettuce client, redisson client ssl 설정을 수정했습니다
운영 서버 redis, 테스트 서버 redis 환경이 달라서 if문과 삼항연산자를 사용했습니다

AWS 인스턴스 생성 + 인스턴스 내부 환경변수 수정 완

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

